### PR TITLE
TOPページ修正

### DIFF
--- a/app/assets/stylesheets/modules/_top-header.scss
+++ b/app/assets/stylesheets/modules/_top-header.scss
@@ -46,8 +46,11 @@
       margin: 8px 0 0;
       @include clearfix();
       h2:hover {
+        .fa.fa-heart, .fa.fa-bell, .fa.fa-check {
+          color: #b3d4fc;
+        }
         span {
-          color: lightblue;
+          color: #b3d4fc;
         }
       }
       .side {
@@ -73,7 +76,7 @@
                 font-size: 16px;
               }
               span {
-                vertical-align: middle;
+                line-height: 44px;
               }
             }
           }
@@ -124,6 +127,40 @@
             margin-left: 10px;
             font-size: 14px;
             vertical-align: middle;
+          }        
+        }
+        .user-link {
+          display: flex;
+          .signup {
+            text-align: center;
+            .user-link__signup {
+              box-sizing: border-box;
+              background-color: rgb(234, 53, 45);
+              color: rgb(255, 255, 255);
+              border-width: 0.5px;
+              border-style: solid;
+              border-color: rgb(234, 53, 45);
+              border-radius: 4px;
+              padding: 6px 14px;
+            }
+          }
+          .signin {
+            text-align: center;
+            margin-left: 11px;
+            .user-link__signin {
+              box-sizing: border-box;
+              background-color: rgb(255, 255, 255);
+              color: rgb(0, 149, 238);
+              border-width: 0.5px;
+              border-style: solid;
+              border-color: rgb(0, 149, 238);
+              border-radius: 4px;
+              padding: 6px 14px;
+            }
+          }
+          .user-link__signin:hover {
+            background-color:  rgb(0, 149, 238);
+            color: rgb(255, 255, 255);
           }
         }
       }

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -22,24 +22,39 @@
                 %span ブランドから探す 
       .right-side
         %ul.side
-          %li
-            %h2
-              = link_to "#" do
-                = fa_icon 'heart'
-                %span いいね一覧
-          %li
-            %h2
-              = link_to "#" do
-                = fa_icon 'bell'
-                %span お知らせ
-          %li
-            %h2
-              = link_to "#" do
-                = fa_icon 'check'
-                %span やることリスト
-          %li
-            %h2
-              = link_to "#" do
-                %div.mypage
-                  = image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'            
-                %span マイページ
+          - if current_user
+            -# 一時的に設置、マイページ上にログアウトボタンを作成した後で消す
+            %li
+              %h2
+                = link_to destroy_user_session_path do
+                  %span ログアウト
+            - unless current_page?(root_path)
+              %li
+                %h2
+                  = link_to "#" do
+                    = fa_icon 'heart'
+                    %span いいね一覧
+            %li
+              %h2
+                = link_to "#" do
+                  = fa_icon 'bell'
+                  %span お知らせ
+            %li
+              %h2
+                = link_to "#" do
+                  = fa_icon 'check'
+                  %span やることリスト
+            %li
+              %h2
+                = link_to "#" do
+                  %div.mypage
+                    = image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'            
+                  %span マイページ
+          - else
+            .user-link
+              .signup
+                = link_to new_user_registration_path, class: 'user-link__signup' do
+                  新規会員登録
+              .signin
+                = link_to new_user_session_path, class: 'user-link__signin' do
+                  ログイン      


### PR DESCRIPTION
## what
・topページ修正、新たにブランチを切って、新規登録、ログインページに遷移できるアイコンを設置(未ログイン時のみ表示)。
・いいね一覧をtopページでは表示しないように変更。
・お知らせ、やることリスト、マイページをログイン時のみ表示させるように変更、一時的にログアウトボタンの設置(あとで削除する)

## why
TOPページから新規登録、ログインページに遷移させるため

[![Image from Gyazo](https://i.gyazo.com/4497c4b61cf0174cf4580ea6c6be608b.gif)](https://gyazo.com/4497c4b61cf0174cf4580ea6c6be608b)