### PR TITLE
20190929060415_add_deleted_at_to_users.rbの削除

### DIFF
--- a/db/migrate/20190929035528_add_deleted_at_to_users.rb
+++ b/db/migrate/20190929035528_add_deleted_at_to_users.rb
@@ -1,5 +1,0 @@
-class AddDeletedAtToUsers < ActiveRecord::Migration[5.0]
-  def change
-    add_column :users, :deleted_at, :datetime, after: :updated_at
-  end
-end


### PR DESCRIPTION
## what
db/migrate/20190929035528_add_deleted_at_to_users.rbの削除

## why
20190929060415_add_deleted_at_to_users.rbとカラムの削除項目が被っていたため削除する