### PR TITLE
商品編集機能の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,23 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  def edit
+    redirect_to new_user_session_url unless user_signed_in?
+    @item = Item.find(params[:id])
+    10.times { @item.images.build }
+
+    @category0 = Category.eager_load(children: {children: :children}).where(parent_id: 0)
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update!(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
   
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_image
+  before_action :set_item, only: [:edit, :update]
 
   def index
     @ladyitems = get_items(1)
@@ -33,14 +34,12 @@ class ItemsController < ApplicationController
 
   def edit
     redirect_to new_user_session_url unless user_signed_in?
-    @item = Item.find(params[:id])
     10.times { @item.images.build }
 
     @category0 = Category.eager_load(children: {children: :children}).where(parent_id: 0)
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update!(item_params)
       redirect_to root_path
     else
@@ -54,6 +53,10 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :price, :description, :category_id, :condition, 
     :shipping_fee, :shipping_from, :days_before_shipping, :shipping_method, 
     :trade_status, images_attributes: [:name, :id]).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   def set_image

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -102,6 +102,6 @@
           %P #{prohibited_items}、#{prohibited_conduct}を必ずご確認ください。
           %P またブランド品でシリアルナンバー等がある場合はご記載ください。#{counterfeit_goods}は犯罪であり処罰される可能性があります。
           %P また、出品をもちまして#{seller_terms}に同意したことになります。
-          = f.submit '出品する', class: "submit-btn"
+          = f.submit '変更する', class: "submit-btn"
           = link_to 'もどる', :back, class:"back-btn"
 = render "shared/single-footer"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,107 @@
+= render "shared/single-header"
+.single-main
+  .sell-container
+    %h2.sell-container__title 商品の情報を入力
+    .sell-contents
+      = form_for @item, url: { action: "update" } do |f|
+        = f.hidden_field :user_id, value: "#{current_user.id}"
+        .sell-content
+          .sell-content__images
+            %h3 出品画像
+            %span 必須
+            %p 最大10枚までアップロードできます
+            #sell-images-area
+              .sell-content__image
+                = f.fields_for :images do |image|
+                  = image.file_field :name
+        .sell-content
+          = f.label :name, "商品名"
+          %span 必須
+          = f.text_field :name, placeholder: "商品名（必須40文字まで）", class: "input-default"
+          .sell-content__margin
+            = f.label :description, "商品の説明"
+            %span 必須
+            = f.text_area :description, placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "textarea-default"
+        .sell-content
+          .sell-content__sub-head 
+            %h3 商品の詳細
+          .sell-content__groups
+            .sell-content__group#sell-content-category
+              = f.label :category_id, "カテゴリー"
+              %span 必須
+            .sell-selector#category0
+              = f.collection_select :category_id, @category0, :id, :name, {include_blank: "---"}, class: "select-default"
+              %i.fa.fa-chevron-down.select-default-arrow
+            -# 以下は仮おき。カテゴリーの絞り込みはJSを経由する。
+            -# .sell-selector#category1
+            -#   = f.collection_select :category_id, @category1, :id, :name, {include_blank: "---"}, class: "select-default"
+            -#   %i.fa.fa-chevron-down.select-default-arrow
+            -# .sell-selector#category2
+            -#   = f.collection_select :category_id, @category2, :id, :name, {include_blank: "---"}, class: "select-default"
+            -#   %i.fa.fa-chevron-down.select-default-arrow
+            .sell-content__group.sell-content__margin
+              = f.label :condition, "商品の状態"
+              %span 必須
+              .sell-selector
+                = f.select :condition,[["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]], {include_blank: "---"}, class: "select-default"
+                %i.fa.fa-chevron-down.select-default-arrow
+        .sell-content
+          .sell-content__sub-head 
+            %h3 配送について
+            %i.fa.fa-question-circle
+          .sell-content__groups
+            .sell-content__group
+              = f.label :shipping_fee, "配送料の負担"
+              %span 必須 
+              .sell-selector  
+                = f.select :shipping_fee, [["送料込み(出品者負担)", 1],["着払い(購入者負担)", 2]], {include_blank: "---"}, class: "select-default"
+                %i.fa.fa-chevron-down.select-default-arrow
+            .sell-content__group.sell-content__margin
+              = f.label :shipping_method, "発送の方法"
+              %span 必須
+              .sell-selector
+                = f.select :shipping_method, [["未定", 1],["クロネコヤマト", 2],["ゆうパック", 3],["ゆうメール", 4]], {include_blank: "---"}, class: "select-default"
+                %i.fa.fa-chevron-down.select-default-arrow
+            .sell-content__group.sell-content__margin
+              = f.label :shipping_from, "発送元の地域"
+              %span 必須
+              .sell-selector
+                = f.collection_select :shipping_from, Prefecture.all, :id, :name, {include_blank: "---"}, class: "select-default"
+                %i.fa.fa-chevron-down.select-default-arrow
+            .sell-content__group.sell-content__margin
+              = f.label :days_before_shipping, "発送までの日数"
+              %span 必須
+              .sell-selector
+                = f.select :days_before_shipping,[["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {include_blank: "---"}, class: "select-default"
+                %i.fa.fa-chevron-down.select-default-arrow
+        .sell-content
+          .sell-content__sub-head
+            %h3 販売価格(300〜9,999,999)
+            %i.fa.fa-question-circle
+          .sell-content__calc
+            %ul
+              %li.price
+                .li-left.li-left-price
+                  = f.label :price, "価格"
+                  %span 必須
+                .li-right
+                  .li-right__input
+                    %a &#165;
+                    = f.text_field :price, placeholder: "例）300", class: "li-right__input-default"
+              %li.commission
+                .li-left 販売手数料(10%)
+                .li-right#commission &#045;
+              %li.profit
+                .li-left 販売利益
+                .li-right#profit &#045;
+        .sell-content__submit
+          - prohibited_items = link_to "禁止されている出品","#", target: :_blank
+          - prohibited_conduct = link_to "行為","#", target: :_blank
+          - counterfeit_goods = link_to "偽ブランドの販売", "#", target: :_blank
+          - seller_terms = link_to "加盟店規約", "#"
+          %P #{prohibited_items}、#{prohibited_conduct}を必ずご確認ください。
+          %P またブランド品でシリアルナンバー等がある場合はご記載ください。#{counterfeit_goods}は犯罪であり処罰される可能性があります。
+          %P また、出品をもちまして#{seller_terms}に同意したことになります。
+          = f.submit '出品する', class: "submit-btn"
+          = link_to 'もどる', :back, class:"back-btn"
+= render "shared/single-footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     resources :profiles, only: [:edit]
   end
 
-  resources :items, only: [:index, :new, :create, :show] do
+  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
     resources :images, only:[:index, :create]
   end
     

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ end
 # user一覧、profile一覧
 user_id = 1
 while user_id <= 10
-  test_user = User.create!(nickname: "test#{user_id}", email: "test#{user_id}@gmail.com", password: '12345678', password_confirmation: '12345678')
+  test_user = User.create!(nickname: "test#{user_id}", email: "test#{user_id}@gmail.com", password: '1234qwer', password_confirmation: '1234qwer')
   test_profile = Profile.create!(body: "よろしく！", last_name: "てすと#{user_id}", first_name: "太郎#{user_id}", last_name_kana: "テスト#{user_id}", first_name_kana: "タロウ#{user_id}", birth_year: 2000, birth_month: 1, birth_day: 1, phone_number: 123456789, user_id: user_id)
   user_id += 1
 end


### PR DESCRIPTION
## what
・items/edit, updateアクションの設定
・items/editに対応するviewの作成(items/newを流用)
・バリデーションの追加に伴い、seed内におけるuserのパスワードを変更

## why
出品された商品の内容を変更するため

 ## 参考画像
・TOP画面
[![Image from Gyazo](https://i.gyazo.com/db6b351a32721805cdc709248675eed9.png)](https://gyazo.com/db6b351a32721805cdc709248675eed9)

・商品編集画面
[![Image from Gyazo](https://i.gyazo.com/e8c3b67c825184de585da8f39b7288be.png)](https://gyazo.com/e8c3b67c825184de585da8f39b7288be)

・編集登録後TOP画面に戻る
[![Image from Gyazo](https://i.gyazo.com/de8228dd16f357afdcb1352701514465.png)](https://gyazo.com/de8228dd16f357afdcb1352701514465)