### PR TITLE
商品購入ページ修正

### DIFF
--- a/app/assets/stylesheets/users_signup/_index.scss
+++ b/app/assets/stylesheets/users_signup/_index.scss
@@ -1,6 +1,5 @@
 * {
   text-decoration: none;
-  color: black;
 }
 
 .single-main {

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -2,8 +2,9 @@ class PurchaseController < ApplicationController
 
   require 'payjp'
 
+  before_action :set_item
+
   def index
-    @item = Item.find(params[:id])
     card = current_user.cards.first
       #テーブルからpayjpの顧客IDを検索
     if card.blank?
@@ -19,15 +20,12 @@ class PurchaseController < ApplicationController
   end
 
   def done
-    @item = Item.find(params[:id])
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def pay
-    @item = Item.find(params[:id])
     card = current_user.cards.first
     Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     Payjp::Charge.create(
@@ -36,6 +34,12 @@ class PurchaseController < ApplicationController
     currency: 'jpy', #日本円    
     )
     redirect_to action: 'done' #完了画面に移動
+  end
+
+  private
+
+  def set_item
+    @item = Item.find(params[:id])
   end
   
 end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -3,6 +3,7 @@ class PurchaseController < ApplicationController
   require 'payjp'
 
   def index
+    @item = Item.find(params[:id])
     card = current_user.cards.first
       #テーブルからpayjpの顧客IDを検索
     if card.blank?
@@ -17,16 +18,22 @@ class PurchaseController < ApplicationController
     end
   end
 
+  def done
+    @item = Item.find(params[:id])
+  end
+
   def show
+    @item = Item.find(params[:id])
   end
 
   def pay
+    @item = Item.find(params[:id])
     card = current_user.cards.first
     Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     Payjp::Charge.create(
-    :amount => 724, #支払い金額を入力(itemテーブルに紐づけてもいい)
-    :customer => card.customer_id, #顧客ID
-    :currency => 'jpy', #日本円    
+    amount: @item.price, #支払い金額
+    customer: card.customer_id, #顧客ID
+    currency: 'jpy', #日本円    
     )
     redirect_to action: 'done' #完了画面に移動
   end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,3 +1,4 @@
 class Card < ApplicationRecord
   belongs_to :user
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,7 @@ class Item < ApplicationRecord
   belongs_to :category, optional: true
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images
-
+  belongs_to :card
   has_many :images
   
   validates :name, length: { maximum: 40 }

--- a/app/views/card/paying.html.haml
+++ b/app/views/card/paying.html.haml
@@ -1,7 +1,5 @@
 .wrapper-wallets
   = render partial: 'shared/header'
-  - breadcrumb :paying
-  = render partial: 'render/breadcrumbs'
   .container
     .content-side-bar
     .content

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -14,10 +14,10 @@
               .section-buy__main__content-item__photo
                 = image_tag '/images/purchase-test.jpg' ,size: "128x128" ,alt: "商品写真" ,class:"item-photo"
               .item__name
-                アイテム名
+                = @item.name
       .price-fee-box
         .price-fee-box__price
-          ¥ 724
+          = number_to_currency(@item.price, unit: "￥", precision: 0 )
           .price-fee-box__shipping-fee
             送料込み
 

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -12,7 +12,7 @@
           .section-buy__main
             .section-buy__main__content-item
               .section-buy__main__content-item__photo
-                = image_tag '/images/purchase-test.jpg' ,size: "128x128" ,alt: "商品写真" ,class:"item-photo"
+                = image_tag ("#{@item.images[0].name}") ,size: "128x128" ,alt: "商品写真" ,class:"item-photo"
               .item__name
                 = @item.name
       .price-fee-box

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -13,10 +13,10 @@
         .section-buy__main__content-item__photo
           = image_tag "/images/purchase-test.jpg", size: "128x128", alt: "商品写真", class: "item-photo"
         .section-buy__main__content-item__name
-          アイテム名
+          = @item.name
         .section-buy__main__content-item__price-fee-box
           .section-buy__main__content-item__price-fee-box__price
-            ¥ 724
+            = number_to_currency(@item.price, unit: "￥", precision: 0 )
 
           .section-buy__main__content-item__price-fee-box__shipping-fee
             送料込み
@@ -30,7 +30,7 @@
             支払い金額
         .section-buy__main__price__display
           .section-buy__main__price__display__fee
-            ¥ 724
+            = number_to_currency(@item.price, unit: "￥", precision: 0 )
       = form_tag(action: :pay, method: :post) do
         %button.red_btn 購入する
 

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -11,7 +11,7 @@
     .section-buy__main
       .section-buy__main__content-item
         .section-buy__main__content-item__photo
-          = image_tag "/images/purchase-test.jpg", size: "128x128", alt: "商品写真", class: "item-photo"
+          = image_tag ("#{@item.images[0].name}"), size: "128x128", alt: "商品写真", class: "item-photo"
         .section-buy__main__content-item__name
           = @item.name
         .section-buy__main__content-item__price-fee-box

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -9,7 +9,7 @@
     .section-buy__main
       .section-buy__main__content-item
         .section-buy__main__content-item__photo
-          = image_tag "/images/purchase-test.jpg", size: "128x128", alt: "商品写真", class: "item-photo"
+          = image_tag ("#{@item.images[0].name}"), size: "128x128", alt: "商品写真", class: "item-photo"
         .section-buy__main__content-item__name
           = @item.name
         .section-buy__main__content-item__price-fee-box

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -9,7 +9,7 @@
     .section-buy__main
       .section-buy__main__content-item
         .section-buy__main__content-item__photo
-          = image_tag @item.images.name, size: "128x128", alt: "商品写真", class: "item-photo"
+          = image_tag "/images/purchase-test.jpg", size: "128x128", alt: "商品写真", class: "item-photo"
         .section-buy__main__content-item__name
           = @item.name
         .section-buy__main__content-item__price-fee-box

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -9,12 +9,12 @@
     .section-buy__main
       .section-buy__main__content-item
         .section-buy__main__content-item__photo
-          = image_tag "/images/purchase-test.jpg", size: "128x128", alt: "商品写真", class: "item-photo"
+          = image_tag @item.images.name, size: "128x128", alt: "商品写真", class: "item-photo"
         .section-buy__main__content-item__name
-          アイテム名
+          = @item.name
         .section-buy__main__content-item__price-fee-box
           .section-buy__main__content-item__price-fee-box__price
-            ¥ 724
+            = number_to_currency(@item.price, unit: "￥", precision: 0 )
 
           .section-buy__main__content-item__price-fee-box__shipping-fee
             送料込み
@@ -28,7 +28,7 @@
             支払い金額
         .section-buy__main__price__display
           .section-buy__main__price__display__fee
-            ¥ 724
+            = number_to_currency(@item.price, unit: "￥", precision: 0 )
       %p.error-text 発送先と支払い方法の入力を完了してください。
       %button.gray_btn 購入する
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,12 +40,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :purchase, only: [:index] do
+  resources :purchase, only: [:index, :show] do
     collection do
-      get 'show',  to: 'purchase#show'
-      get 'index', to: 'purchase#index'
-      post 'pay',  to: 'purchase#pay'
-      get 'done',  to: 'purchase#done'
+      get  'show',  to: 'purchase#show'
+      get  '/:id/index', to: 'purchase#index',as:"item_buy"
+      post '/:id/pay',   to: 'purchase#pay',as:"item_pay"
+      get  '/:id/done',  to: 'purchase#done',as:"buy_done"
     end
   end
 end


### PR DESCRIPTION
# WHAT

商品購入ページのpathの修正
・/:id/show（クレジット未登録時表示ページ）
・/:id/index（クレジット登録時表示ページ）
・/:id/pay（商品購入中）
・/:id/done（商品購入完了）に修正

show, index, doneで商品名、画像、金額をitemテーブルから引っ張ってこれるように修正

 # WHY
選択した商品がきちんと表示されるようにするため
![9c510e4ad3074280861bdfb780702333](https://user-images.githubusercontent.com/51727861/68016373-cd0f2200-fcd7-11e9-9ac3-88f6ddcf1af6.gif)
