### PR TITLE
新規登録ページのViewを追加(名前・名前カナ・生年月日)

### DIFF
--- a/app/assets/stylesheets/mixins/mixin.scss
+++ b/app/assets/stylesheets/mixins/mixin.scss
@@ -115,4 +115,16 @@
   margin-bottom: 10px;
   font-size: 16px;
   padding-left: 15px;
-} 
+}
+
+@mixin select-default {
+  z-index: 2;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/modules/_items-new.scss
+++ b/app/assets/stylesheets/modules/_items-new.scss
@@ -60,19 +60,10 @@
         position: relative;
       }
       .select-default {
-        // selectのデフォルト(適宜共通CSSと置き換え)
-        z-index: 2;
-        height: 48px;
-        padding: 0 16px;
-        border-radius: 4px;
-        border: 1px solid #ccc;
-        background: 0;
-        font-size: 16px;
-        line-height: 1.5;
-        cursor: pointer;
         display: block;
         width: 100%;
         position: relative;
+        @include select-default;
         &-arrow {
           // 任意の下向きの矢を置く場合、クラスに-arrowをつける
           position: absolute;

--- a/app/assets/stylesheets/users_signup/_registration.scss
+++ b/app/assets/stylesheets/users_signup/_registration.scss
@@ -1,9 +1,9 @@
 .signup-registration {
   box-sizing: border-box;
-  .small-link {
+  a.small-link {
     color: $color-blue;
   }
-  a:hover{
+  a.small-link:hover{
     text-decoration: underline;
     opacity: 0.8;
   }

--- a/app/assets/stylesheets/users_signup/_registration.scss
+++ b/app/assets/stylesheets/users_signup/_registration.scss
@@ -1,5 +1,12 @@
 .signup-registration {
   box-sizing: border-box;
+  .small-link {
+    color: $color-blue;
+  }
+  a:hover{
+    text-decoration: underline;
+    opacity: 0.8;
+  }
   .single-main {
     background-color: $color-white;
     color: $color-black;
@@ -34,12 +41,25 @@
           height: 28px;
           margin-top: 8px;
           @include input-default;
+          &-half {
+            width: calc(50% - 40px);
+            height: 28px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+            background: #fff;
+            font-size: 16px;
+            padding: 10px 16px 8px;
+            margin-top: 8px;
+            &__first {
+              margin-right: 4px;
+            }
+          }
         }
         label {
           font-weight: 600;
           font-size: 14px;
         }
-        span {
+        span.require {
           // 必須表示
           font-size: 12px;
           font-weight: bold;
@@ -50,11 +70,70 @@
           border-radius: 2px;
           vertical-align: top;
         }
+        span.date {
+          font-size: 14px;
+        }
+        &__sub {
+          &-head {
+          margin-top: 32px;
+          font-weight: 600;
+          font-size: 16px;
+          }
+          &-txt {
+            margin: 8px 0 0;
+            padding: 0;
+            font-size: 14px;
+            line-height: 1.5;
+          }
+        }
+        &__name {
+          width: 100%;
+        }
+        &__birth {
+          height: 56px;
+          .birth-selector{
+            position: relative;
+            padding: 0;
+            margin: 0;
+            width: 76px;
+            display: inline-block;
+            .select-default {
+              padding: 0 10px;
+              width: 100%;
+              @include select-default;
+              &-arrow {
+                // 任意の下向きの矢を置く場合、クラスに-arrowをつける
+                position: absolute;
+                right: 16px;
+                top: 50%;
+                -webkit-transform: translate(0, -50%);
+                transform: translate(0, -50%);
+                color: gray;
+              }
+            }
+          }
+          select {
+            // デフォルトの下向きの矢を非表示
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            appearance: none;
+          }
+          ::-ms-expand {
+            display: none;
+          }
+        }
+        .caution {
+          color: #888;
+          font-size: 14px;
+          margin: 8px 0 0;
+          line-height: 1.5;
+        }
       }
       &__comment {
         max-width: 343px;
         margin: 32px auto 0;
         font-size: 14px;
+        text-align: center;
       }
       &__submit {
         width: 343px;
@@ -81,3 +160,4 @@
     }
   }
 }
+

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,33 +10,74 @@
           .signup-registrations-content.input-group
             .signup-registrations-content__nickname
               = f.label :nickname, "ニックネーム"
-              %span 必須
+              %span.require 必須
             .signup-registrations-content__txt
               = f.text_field :nickname, placeholder: "例）メルカリ太郎", autofocus: true, class: "input-default"
           .signup-registrations-content.input-group__next
             .signup-registrations-content__email
               = f.label :email, "メールアドレス"
-              %span 必須
+              %span.require 必須
             .signup-registrations-content__txt
               = f.text_field :email, placeholder: "PC・携帯どちらでも可", autofocus: true, class: "input-default"
           .signup-registrations-content.input-group__next
             .signup-registrations-content__password
               = f.label :password, "パスワード"
-              %span 必須
+              %span.require 必須
             .signup-registrations-content__txt
               = f.password_field :password, placeholder: "7文字以上", autofocus: true, class: "input-default"
           .signup-registrations-content.input-group__next
             .signup-registrations-content__password_confirmation
               = f.label :password_confirmation, "パスワード(確認)"
-              %span 必須
+              %span.require 必須
             .signup-registrations-content__txt
               = f.password_field :password_confirmation, placeholder: "7文字以上", autofocus: true, class: "input-default"
+          .signup-registrations-content
+            %h3.signup-registrations-content__sub-head 本人確認
+            %p.signup-registrations-content__sub-txt 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+
+          .signup-registrations-content.input-group__next
+            .signup-registrations-content__txt
+              %label お名前(全角)
+              -# %span.require 必須
+            .signup-registrations-content__name
+              %input.input__first-name.input-default-half.input-default-half__first
+              %input.input__last-name.input-default-half
+
+          .signup-registrations-content.input-group__next
+            .signup-registrations-content__txt
+              %label お名前カナ(全角)
+              -# %span.require 必須
+            .signup-registrations-content__name
+              %input.input__first-name_kana.input-default-half.input-default-half__first
+              %input.input__last-name_kana.input-default-half
+
+          .signup-registrations-content.input-group__next
+            %label 生年月日
+            -# %span.require 必須
+            .signup-registrations-content__birth
+              .birth-selector
+                %select.select-default
+                %i.fa.fa-chevron-down.select-default-arrow
+              %span 年
+              .birth-selector
+                %select.select-default
+                %i.fa.fa-chevron-down.select-default-arrow
+              %span 月
+              .birth-selector
+                %select.select-default
+                %i.fa.fa-chevron-down.select-default-arrow
+              %span 日
+
+          .signup-registrations-content
+            .caution
+              %p ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+              
           .signup-registrations__comment
-            - tos = link_to "利用規約","#", target: :_blank
+            - tos = link_to "利用規約","#", target: :_blank, class: "small-link"
             %P 次のボタンを押すことにより、#{tos}に同意したものとみなします
           .signup-registrations__submit
             = f.submit "登録する", class: "submit-btn"
           .signup-registrations__about
             %p
-              = link_to "本人情報の登録について＞", "#"
+              = link_to "本人情報の登録について＞", "#", class: "small-link"
   = render "shared/single-footer"


### PR DESCRIPTION
# What
- `signup/registration`に名前・生年月日などの欄を追加(viewのみ)
- サーバーサイドとつながっていないため`必須`表示はコメントアウトしている
- 現時点では、これまでの項目のみで新規登録が可能

# Why
- 新規登録時にProfileの項目を含めた入力を必須とするため

![registration01](https://user-images.githubusercontent.com/52348865/68524407-ea607380-0309-11ea-9748-653a7d39d4f2.png)