### PR TITLE
ユーザー新規登録ページにreCAPTCHAを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,4 @@ gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem 'ransack'
 gem 'twilio-ruby'
+gem "recaptcha", require: "recaptcha/rails"

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'rails-i18n', '~> 5.1'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -417,6 +420,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.2.3)
   rails-controller-testing
+  rails-i18n (~> 5.1)
   ransack
   recaptcha
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     jquery-turbolinks (2.1.0)
       railties (>= 3.1.0)
       turbolinks
+    json (2.2.0)
     jwt (2.2.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -286,6 +287,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    recaptcha (5.2.1)
+      json
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -415,6 +418,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   ransack
+  recaptcha
   rspec-rails
   sass-globbing
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/users_signup/_registration.scss
+++ b/app/assets/stylesheets/users_signup/_registration.scss
@@ -31,7 +31,15 @@
           margin-top: 32px;
           }
         }
+        .error {
+          color: $color-red;
+          padding-top: 8px;
+          padding-bottom: 24px;
+          line-height: 1.5;
+          font-size: 14px;
+        }
       }
+      
       &-content {
         max-width: 343px;
         height: 70px;
@@ -159,5 +167,9 @@
       }
     }
   }
+  .field_with_errors {
+    display: contents;
+    // もしくは diplay: inline;
+  } 
 }
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,12 +1,22 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :authenticate_user!
+  prepend_before_action :check_captcha, only: [:create]
+  prepend_before_action :customize_sign_up_params, only: [:create]
   
-#   def mypage
-#   end
- 
-#   protected
- 
   def after_sign_up_path_for(resource)
      guide_beginner_path
+  end
+
+  private
+  def customize_sign_up_params
+    devise_parameter_sanitizer.permit :sign_up, keys: [:username, :email, :password, :password_confirmation, :remember_me]
+  end
+
+  def check_captcha
+    self.resource = resource_class.new sign_up_params
+    resource.validate
+    unless verify_recaptcha(model: resource)
+      flash.now[:recaptcha_error] = I18n.t('recaptcha.errors.verification_failed')
+      respond_with_navigational(resource) { render :new }
+    end
   end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -71,7 +71,11 @@
           .signup-registrations-content
             .caution
               %p ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-              
+          .signup-registrations-content.recaptcha
+            = recaptcha_tags
+            %p
+              %span.error
+                = flash[:recaptcha_error] 
           .signup-registrations__comment
             - tos = link_to "利用規約","#", target: :_blank, class: "small-link"
             %P 次のボタンを押すことにより、#{tos}に同意したものとみなします

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title
       = content_for?(:title) ? yield(:title) + ' | FreemarketSample53b' : 'FreemarketSample53b' 
+    %script{src: "https://www.google.com/recaptcha/api.js"}
+    %link{href: "https://www.google.com/recaptcha/api.js", rel: "stylesheet"}/
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+
 module FreemarketSample53b
   class Application < Rails::Application
     config.generators do |g|
@@ -13,6 +14,13 @@ module FreemarketSample53b
       g.javascripts false
       g.helper false
       g.test_framework false
+
+      config.time_zone = 'Tokyo'
+      config.active_record.default_timezone = :local
+      config.i18n.default_locale = :ja
+
+      config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     end
   end
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key = ENV['RECAPTCHA_PUBLIC_KEY']
+  config.secret_key = ENV['RECAPTCHA_PRIVATE_KEY']
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  recaptcha: 
+    errors: 
+      verification_failed: 'reCAPTCHA認証に失敗しました。' 


### PR DESCRIPTION
# What
・新規登録画面にreCAPTCHAを導入
・エラーメッセージの日本語化( gem rails-i18n のインストール)
# Why
・スパム対策、悪質なアクセスを防ぐため
# Preview
![recaptcha](https://user-images.githubusercontent.com/52348865/68913189-d69b8e00-079d-11ea-98e0-aed46e016c78.gif)

