### PR TITLE
作業状況にあわせた各ページの最適化

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,21 +1,24 @@
+$(document).on('turbolinks:load', function(){
 
-jQuery(function($){
-  $('.tab').click(function(){
-      $('.is-active').removeClass('is-active');
-      $(this).addClass('is-active');
-      $('.is-show').removeClass('is-show');
-      // クリックしたタブからインデックス番号を取得
-      const index = $(this).index();
-      // クリックしたタブと同じインデックス番号をもつコンテンツを表示
-      $('.panel').eq(index).addClass('is-show');
+  jQuery(function($){
+    $('.tab').click(function(){
+        $('.is-active').removeClass('is-active');
+        $(this).addClass('is-active');
+        $('.is-show').removeClass('is-show');
+        // クリックしたタブからインデックス番号を取得
+        const index = $(this).index();
+        // クリックしたタブと同じインデックス番号をもつコンテンツを表示
+        $('.panel').eq(index).addClass('is-show');
+    });
+    $('.tab2').click(function(){
+        $('.is-active2').removeClass('is-active2');
+        $(this).addClass('is-active2');
+        $('.is-show2').removeClass('is-show2');
+        // クリックしたタブからインデックス番号を取得
+        const index = $(this).index();
+        // クリックしたタブと同じインデックス番号をもつコンテンツを表示
+        $('.panel2').eq(index).addClass('is-show2');
+    });
   });
-  $('.tab2').click(function(){
-      $('.is-active2').removeClass('is-active2');
-      $(this).addClass('is-active2');
-      $('.is-show2').removeClass('is-show2');
-      // クリックしたタブからインデックス番号を取得
-      const index = $(this).index();
-      // クリックしたタブと同じインデックス番号をもつコンテンツを表示
-      $('.panel2').eq(index).addClass('is-show2');
-  });
+  
 });

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -2,6 +2,9 @@
   height: 1300px;
   width: 100vw;
   background-color: $color-white;
+  a :link, :visited, :hover, :active {
+    color: $color-black;
+  }
   .container {
     box-sizing: border-box;
     padding-top: 5px;
@@ -31,6 +34,7 @@
       margin-left: 60px;
       &__search-result {
         height: 45px;
+        color: $color-black;
         &__item-name {
           display: inline-block;
           font-size: 25px;

--- a/app/assets/stylesheets/modules/_buy-btn.scss
+++ b/app/assets/stylesheets/modules/_buy-btn.scss
@@ -4,9 +4,11 @@
   text-align: center;
   font-size: 30px;
   width: 60%;
-  margin: auto;
+  margin: 16px auto 0;
   width: 620px;
   border: 0;
+  font-size: 24px;
+  line-height: 60px;
   a:hover {
     color: white;
   }

--- a/app/assets/stylesheets/modules/_item-detail.scss
+++ b/app/assets/stylesheets/modules/_item-detail.scss
@@ -4,15 +4,15 @@
   box-sizing: border-box;
   color: black;
   overflow: visible;
-  width:60%;
   margin:40px auto 40px;
+  padding-bottom: 40px;
   .item-detail-box {
     height: auto;
     width: 700px;
     background-color:white;
     text-align: center;
     margin: 0 auto;
-    padding: 24px 40px 40px;
+    padding: 24px 40px;
   }
   .item-name {
     h1 {
@@ -21,13 +21,17 @@
       margin: auto;
       line-height: 1.4;
     }
+    .item-wording {
+      padding-top: 8px;
+      color: #888;
+      font-size: 14px;
+    }
   }
   .item-table{
-    float: left;
     background-color:white;
     margin-top: 16px;
     width: 100%;
-
+    @include clearfix_after();
     .item-image {
       width: 50%;
       img {
@@ -50,6 +54,13 @@
         margin-left: auto;
         margin-right: auto;
         font-size: 14px;
+        border: 1px solid #f5f5f5;
+        a {
+          color: $color-blue;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
         th {
           width: 39%;
           text-align: left;
@@ -67,13 +78,32 @@
     }
   }
   .item-price{
-    font-size: 50px;
+    font-size: 32px;
     text-align: center;
     background-color: white;
+    padding-top: 24px;
+    .tax-included {
+      font-size: 10px;
+    }
   }
   .item-content{
     font-size: 30px;
     text-align: center;
     background-color: white;
+    padding-top: 32px;
+    .item-description {
+      font-size: 18px;
+      white-space: pre-wrap;
+      margin: 0 40px;
+      text-align: left;
+    }
+  }
+  &__bottom {
+    margin: 0 auto 40px;
+    padding: 24px 40px;
+    height: auto;
+    width: 780px;
+    background-color: white;
+    box-sizing: border-box;
   }
 }

--- a/app/assets/stylesheets/modules/_items-edit-btn.scss
+++ b/app/assets/stylesheets/modules/_items-edit-btn.scss
@@ -1,9 +1,8 @@
 .edit-btn-p {
   text-align: center;
-  font-size: 30px;
 }
 .items-edit-btn {
-  margin-top: 10px;
+  margin-top: 16px;
   .edit-btn {  
     display: block;
     background-color: gray;
@@ -14,5 +13,7 @@
     width: 620px;
     border: 0;
     color: #eee;
+    font-size: 24px;
+    line-height: 60px;
   }
 }

--- a/app/assets/stylesheets/users_signup/_sms_authentification.scss
+++ b/app/assets/stylesheets/users_signup/_sms_authentification.scss
@@ -1,64 +1,66 @@
-a:link,a:visited {
-  color: rgb(0, 195, 255);
-}
+.sms-authentification {
+  a:link,a:visited {
+    color: rgb(0, 195, 255);
+  }
 
-h2 {
-  margin: 10px;
-  text-align: center;
-  margin: 0,175px,0; 
-}
+  h2 {
+    margin: 10px;
+    text-align: center;
+    margin: 0,175px,0; 
+  }
 
-.text_input {
-  width: 340px;
-  height: 50px;
-}
+  .text_input {
+    width: 340px;
+    height: 50px;
+  }
 
-.image__kari {
-  max-width: 100%;
-  margin: 40px 0 0 0;
-}
+  .image__kari {
+    max-width: 100%;
+    margin: 40px 0 0 0;
+  }
 
-.sms_non.message {
-  margin: 0px 25%;
-  font-size: 17px;
-  text-align: left;
-  line-height: 1.5;
-}
+  .sms_non.message {
+    margin: 0px 25%;
+    font-size: 17px;
+    text-align: left;
+    line-height: 1.5;
+  }
 
 
-.sms_non2.message {
-  margin: 0px 25%;
-  font-size: 14px;
-  text-align: left;
-  line-height: 1.5;
-  color: rgb(145, 145, 145);
-}
+  .sms_non2.message {
+    margin: 0px 25%;
+    font-size: 14px;
+    text-align: left;
+    line-height: 1.5;
+    color: rgb(145, 145, 145);
+  }
 
-.sms_non3.message {
-  color: rgb(255, 255, 255);
-}
+  .sms_non3.message {
+    color: rgb(255, 255, 255);
+  }
 
-.btn-default.btn-red2 {
-  display: block;
-  margin: 20px 25%;
-  background: #ea352d;
-  border: 1px solid #ea352d;
-  color: #fff;
-  width: 50%;
-  line-height: 48px;
-  font-size: 14px;
-  border: 1px solid transparent;
-  -webkit-transition: all ease-out .3s;
-  transition: all ease-out .3s;
-  cursor: pointer;
-  text-align: center;
-} 
+  .btn-default.btn-red2 {
+    display: block;
+    margin: 20px 25%;
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+    width: 50%;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    -webkit-transition: all ease-out .3s;
+    transition: all ease-out .3s;
+    cursor: pointer;
+    text-align: center;
+  } 
 
-.single-main__container__header {
-  border-bottom: .99px solid rgb(204, 204, 204);
-}
+  .single-main__container__header {
+    border-bottom: .99px solid rgb(204, 204, 204);
+  }
 
-.why {
-  font-size: 14px;
-  margin: 0 0 0 120px ;
+  .why {
+    font-size: 14px;
+    margin: 0 0 0 120px ;
+  }
 }

--- a/app/assets/stylesheets/users_signup/_sms_confirmation.scss
+++ b/app/assets/stylesheets/users_signup/_sms_confirmation.scss
@@ -1,65 +1,67 @@
-a:link,a:visited {
-  color: rgb(0, 195, 255);
-}
+.sms-confirmation {
+  a:link,a:visited {
+    color: rgb(0, 195, 255);
+  }
 
-.qw {
-  margin: 100px 25%;
-  font-size: 14px;
-  text-align: left;
-}
+  .qw {
+    margin: 100px 25%;
+    font-size: 14px;
+    text-align: left;
+  }
 
-h2 {
-  margin: 10px;
-  text-align: center;
-  margin: 0,175px,0; 
-}
+  h2 {
+    margin: 10px;
+    text-align: center;
+    margin: 0,175px,0; 
+  }
 
-.text_input {
-  width: 336px;
-  height: 46px;
-}
+  .text_input {
+    width: 336px;
+    height: 46px;
+  }
 
-.image__kari {
-  max-width: 100%;
-  margin: 40px 0 0 0;
-}
+  .image__kari {
+    max-width: 100%;
+    margin: 40px 0 0 0;
+  }
 
-.sms_non.message {
-  margin: 0px 25%;
-  font-size: 17px;
-  text-align: left;
-  line-height: 1.5;
-}
+  .sms_non.message {
+    margin: 0px 25%;
+    font-size: 17px;
+    text-align: left;
+    line-height: 1.5;
+  }
 
 
-.sms_non2.message {
-  margin: 0px 25%;
-  font-size: 14px;
-  text-align: left;
-  line-height: 1.5;
-  color: rgb(145, 145, 145);
-}
+  .sms_non2.message {
+    margin: 0px 25%;
+    font-size: 14px;
+    text-align: left;
+    line-height: 1.5;
+    color: rgb(145, 145, 145);
+  }
 
-.sms_non3.message {
-  color: rgb(255, 255, 255);
-}
+  .sms_non3.message {
+    color: rgb(255, 255, 255);
+  }
 
-.btn-default.btn-red {
-  display: block;
-  margin: 20px 25% 100px 25%;
-  background: #ea352d;
-  border: 1px solid #ea352d;
-  color: #fff;
-  width: 50%;
-  line-height: 48px;
-  font-size: 14px;
-  border: 1px solid transparent;
-  -webkit-transition: all ease-out .3s;
-  transition: all ease-out .3s;
-  cursor: pointer;
-  text-align: center;
-} 
+  .btn-default.btn-red {
+    display: block;
+    margin: 20px 25% 100px 25%;
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+    width: 50%;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    -webkit-transition: all ease-out .3s;
+    transition: all ease-out .3s;
+    cursor: pointer;
+    text-align: center;
+  } 
 
-.single-main__container__header {
-  border-bottom: .99px solid rgb(204, 204, 204);
+  .single-main__container__header {
+    border-bottom: .99px solid rgb(204, 204, 204);
+  }
 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,31 @@ class Item < ApplicationRecord
   belongs_to :card, optional: true
   
   validates :name, length: { maximum: 40 }
+
+  enum condition:{
+    "新品、未使用": 1,
+    "未使用に近い": 2,
+    "目立った傷や汚れなし": 3,
+    "やや傷や汚れあり": 4,
+    "傷や汚れあり": 5,
+    "全体的に状態が悪い": 6
+  }
+
+  enum shipping_fee:{
+    "送料込み(出品者負担)": 1,
+    "着払い(購入者負担)": 2
+  }
+
+  enum shipping_method:{
+    "未定": 1,
+    "クロネコヤマト": 2,
+    "ゆうパック": 3,
+    "ゆうメール": 4
+  }
+
+  enum days_before_shipping:{
+    "1~2日で発送": 1,
+    "2~3日で発送": 2,
+    "4~7日で発送": 3
+  }
 end

--- a/app/views/items/_buy-btn.html.haml
+++ b/app/views/items/_buy-btn.html.haml
@@ -1,4 +1,9 @@
-.buy-btn
-  =link_to item_buy_purchase_index_path(@item.id) do
-    ="購入画面に進む"
-
+- if @item.user_id == current_user.id
+  %p.edit-btn-p
+  .items-edit-btn
+    = link_to edit_item_path(@item.id), class: "edit-btn" do
+      = "商品を編集する"
+- else
+  .buy-btn
+    =link_to item_buy_purchase_index_path(@item.id) do
+      ="購入画面に進む"

--- a/app/views/items/_edit-btn.html.haml
+++ b/app/views/items/_edit-btn.html.haml
@@ -1,5 +1,0 @@
-- if @item.user_id == current_user.id
-  %p.edit-btn-p
-  .items-edit-btn
-    = link_to edit_item_path(@item.id), class: "edit-btn" do
-      = "商品を編集する"

--- a/app/views/items/_edit-btn.html.haml
+++ b/app/views/items/_edit-btn.html.haml
@@ -1,5 +1,5 @@
 - if @item.user_id == current_user.id
-  %p.edit-btn-p or
+  %p.edit-btn-p
   .items-edit-btn
     = link_to edit_item_path(@item.id), class: "edit-btn" do
       = "商品を編集する"

--- a/app/views/items/_item-detail.html.haml
+++ b/app/views/items/_item-detail.html.haml
@@ -3,6 +3,7 @@
     .item-name
       %h1
         = @item.name 
+      %p.item-wording 『#{@item.name}』は、#{@item.user.nickname}さんから出品されました。#{@item.category.name}の商品です。
     .item-table
       .item-image
         %figure-main
@@ -11,7 +12,7 @@
         %table{:border => "2"}
           %tr
             %th 出品者
-            %td #{@item.user.nickname}
+            %td= link_to "#{@item.user.nickname}", "#"
           %tr
             %th カテゴリー
             %td #{@item.category.name}
@@ -31,7 +32,10 @@
             %th 発送日の目安
             %td #{@item.days_before_shipping}
 
-  .item-price
-    %span ¥#{@item.price.to_s(:delimited)}
-  .item-content
-    %p  #{@item.description}
+    .item-price
+      %span ¥#{@item.price.to_s(:delimited)}
+      %span.tax-included (税込)
+    - if current_user
+      = render partial: 'items/buy-btn'
+    .item-content
+      %p.item-description  #{@item.description}

--- a/app/views/items/_links.html.haml
+++ b/app/views/items/_links.html.haml
@@ -1,2 +1,0 @@
-.test-link
-  test-links,test test

--- a/app/views/items/_other-item.html.haml
+++ b/app/views/items/_other-item.html.haml
@@ -1,15 +1,16 @@
-.item-list
-  .item-list__name
-    %h3 #{@item.user.nickname}のその他の出品
-  .item-list__box
-    .item-list__box-show
-      - @whole_items.each do |item|
-        .visibility
-          = link_to item_path(item.id) do
-            %figure
-              %figcaption.name
-                %span #{item.name}
-              .price
-                %span ¥#{item.price.to_s(:delimited)}
-                = image_tag ("#{item.images[0].name}")
-
+.item-detail__bottom
+  .item-detail-box
+    .item-list
+      .item-list__name
+        %h3 #{@item.user.nickname}のその他の出品
+      .item-list__box
+        .item-list__box-show
+          - @whole_items.each do |item|
+            .visibility
+              = link_to item_path(item.id) do
+                %figure
+                  %figcaption.name
+                    %span #{item.name}
+                  .price
+                    %span ¥#{item.price.to_s(:delimited)}
+                    = image_tag ("#{item.images[0].name}")

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -38,7 +38,7 @@
               = f.label :condition, "商品の状態"
               %span 必須
               .sell-selector
-                = f.select :condition,[["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]], {include_blank: "---"}, class: "select-default"
+                = f.select :condition, Item.conditions.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
         .sell-content
           .sell-content__sub-head 
@@ -49,13 +49,13 @@
               = f.label :shipping_fee, "配送料の負担"
               %span 必須 
               .sell-selector  
-                = f.select :shipping_fee, [["送料込み(出品者負担)", 1],["着払い(購入者負担)", 2]], {include_blank: "---"}, class: "select-default"
+                = f.select :shipping_fee, Item.shipping_fees.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
             .sell-content__group.sell-content__margin
               = f.label :shipping_method, "発送の方法"
               %span 必須
               .sell-selector
-                = f.select :shipping_method, [["未定", 1],["クロネコヤマト", 2],["ゆうパック", 3],["ゆうメール", 4]], {include_blank: "---"}, class: "select-default"
+                = f.select :shipping_method, Item.shipping_methods.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
             .sell-content__group.sell-content__margin
               = f.label :shipping_from, "発送元の地域"
@@ -67,7 +67,7 @@
               = f.label :days_before_shipping, "発送までの日数"
               %span 必須
               .sell-selector
-                = f.select :days_before_shipping,[["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {include_blank: "---"}, class: "select-default"
+                = f.select :days_before_shipping, Item.days_before_shippings.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
         .sell-content
           .sell-content__sub-head

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -38,7 +38,7 @@
               = f.label :condition, "商品の状態"
               %span 必須
               .sell-selector
-                = f.select :condition,[["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]], {include_blank: "---"}, class: "select-default"
+                = f.select :condition, Item.conditions.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
         .sell-content
           .sell-content__sub-head 
@@ -49,13 +49,13 @@
               = f.label :shipping_fee, "配送料の負担"
               %span 必須 
               .sell-selector  
-                = f.select :shipping_fee, [["送料込み(出品者負担)", 1],["着払い(購入者負担)", 2]], {include_blank: "---"}, class: "select-default"
+                = f.select :shipping_fee, Item.shipping_fees.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
             .sell-content__group.sell-content__margin
               = f.label :shipping_method, "発送の方法"
               %span 必須
               .sell-selector
-                = f.select :shipping_method, [["未定", 1],["クロネコヤマト", 2],["ゆうパック", 3],["ゆうメール", 4]], {include_blank: "---"}, class: "select-default"
+                = f.select :shipping_method, Item.shipping_methods.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
             .sell-content__group.sell-content__margin
               = f.label :shipping_from, "発送元の地域"
@@ -67,7 +67,7 @@
               = f.label :days_before_shipping, "発送までの日数"
               %span 必須
               .sell-selector
-                = f.select :days_before_shipping,[["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {include_blank: "---"}, class: "select-default"
+                = f.select :days_before_shipping, Item.days_before_shippings.keys, {include_blank: "---"}, class: "select-default"
                 %i.fa.fa-chevron-down.select-default-arrow
         .sell-content
           .sell-content__sub-head

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -25,10 +25,11 @@
       .container__right__search-item
         .container__right__search-item__results
         - @items.each do |item|
-          .container__right__search-item__results__box
-            .container__right__search-item__results__box__image-box
-              = image_tag ("#{item.images[0].name}"), alt: '画像１', class: 'owl-box'
-            .container__right__search-item__results__box__image-box__name-box
-              = item.name
-            .container__right__search-item__results__box__image-box__price
-              = number_to_currency(item.price, unit: "￥", precision: 0 )
+          = link_to item_path(item) do
+            .container__right__search-item__results__box
+              .container__right__search-item__results__box__image-box
+                = image_tag ("#{item.images[0].name}"), alt: '画像１', class: 'owl-box'
+              .container__right__search-item__results__box__image-box__name-box
+                = item.name
+              .container__right__search-item__results__box__image-box__price
+                = number_to_currency(item.price, format: "%u%n", unit: "¥", precision: 0 )

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,8 +5,6 @@
   = render partial: 'shared/header'
   = render partial: 'items/item-detail'
   - if current_user
-    = render partial: 'items/edit-btn'
-  - else
     = render partial: 'items/buy-btn'
   -# = render partial: 'items/item-comments'
   = render partial: 'items/other-item'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -4,8 +4,7 @@
 .wrapper
   = render partial: 'shared/header'
   = render partial: 'items/item-detail'
-  - if current_user
-    = render partial: 'items/buy-btn'
+
   -# = render partial: 'items/item-comments'
   = render partial: 'items/other-item'
   = render partial: 'shared/app-baner'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -4,11 +4,11 @@
 .wrapper
   = render partial: 'shared/header'
   = render partial: 'items/item-detail'
-  = render partial: 'items/buy-btn'
   - if current_user
     = render partial: 'items/edit-btn'
+  - else
+    = render partial: 'items/buy-btn'
   -# = render partial: 'items/item-comments'
-  = render partial: 'items/links'
   = render partial: 'items/other-item'
   = render partial: 'shared/app-baner'
   = render partial: 'shared/footer'

--- a/app/views/signup/sms_authentication.html.haml
+++ b/app/views/signup/sms_authentication.html.haml
@@ -1,18 +1,19 @@
-- content_for :title do
-  電話番号認証
-.single-container
-  = render 'shared/single-header'
-  %main.single-main
-    %section.single-main__container
-      .single-main__container__header 電話番号の確認
-      %h2.form
-        = form_for @profile, url: sms_authentication_signup_index_path,method: :post do |f|
-          = label :nickname, '携帯電話の番号'
-          %h2.textbox
-          = f.text_field :phone_number, placeholder: '携帯電話の番号を入力', class: "text_input"
-          %p.registration-form-text.sms_non2.message 本人確認のため、携帯電話のSMS（ショートメッセージサービス）を利用して認証を行います。
-          = f.submit 'SMSを送信する',class: "btn-default btn-red2"
-          %p.sms_non2.message ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
-          %p.sms_non3.message - 
-          = link_to "電話番号の確認が必要な理由>" , "#", class: "why"
-          %image.image__kari{src: "https://i.gyazo.com/3115ad076f4ae0ac5d647ccec944218e.png"}
+.sms-authentification
+  - content_for :title do
+    電話番号認証
+  .single-container
+    = render 'shared/single-header'
+    %main.single-main
+      %section.single-main__container
+        .single-main__container__header 電話番号の確認
+        %h2.form
+          = form_for @profile, url: sms_authentication_signup_index_path,method: :post do |f|
+            = label :nickname, '携帯電話の番号'
+            %h2.textbox
+            = f.text_field :phone_number, placeholder: '携帯電話の番号を入力', class: "text_input"
+            %p.registration-form-text.sms_non2.message 本人確認のため、携帯電話のSMS（ショートメッセージサービス）を利用して認証を行います。
+            = f.submit 'SMSを送信する',class: "btn-default btn-red2"
+            %p.sms_non2.message ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
+            %p.sms_non3.message - 
+            = link_to "電話番号の確認が必要な理由>" , "#", class: "why"
+            %image.image__kari{src: "https://i.gyazo.com/3115ad076f4ae0ac5d647ccec944218e.png"}

--- a/app/views/signup/sms_confirmation.html.haml
+++ b/app/views/signup/sms_confirmation.html.haml
@@ -1,29 +1,30 @@
-- content_for :title do
-  電話番号認証
-.single-container
-  = render 'shared/single-header'
-  %main.single-main
-    %section.single-main__container
-      .single-main__container__header 電話番号認証
-      %h2.form
-        = form_for @profile, url: sms_confirmation_signup_index_path,method: :post do |f|
-          = label :sms_number, '認証番号', class: "sms_non.message"
-          %h2.textbox
-          = f.text_field :phone_number, placeholder: '認証番号を入力', class: "text_input"
-          %p.registration-form-text.sms_non2.message SMSで届いた認証番号を入力してください
-          = f.submit '認証して完了',class: "btn-default btn-red"
-      
-      %form.registration-form
-        .registration-form__content
-          %p.sms_non.message 30秒たっても認証番号が届かない方へ
-          %p.sms_non2.message 電話で認証番号を聞くこともできます。
-          %button.btn-default.btn-red{type: "~/signup/address"} 電話で認証番号を聞く（通話無料）
+.sms-confirmation
+  - content_for :title do
+    電話番号認証
+  .single-container
+    = render 'shared/single-header'
+    %main.single-main
+      %section.single-main__container
+        .single-main__container__header 電話番号認証
+        %h2.form
+          = form_for @profile, url: sms_confirmation_signup_index_path,method: :post do |f|
+            = label :sms_number, '認証番号', class: "sms_non.message"
+            %h2.textbox
+            = f.text_field :phone_number, placeholder: '認証番号を入力', class: "text_input"
+            %p.registration-form-text.sms_non2.message SMSで届いた認証番号を入力してください
+            = f.submit '認証して完了',class: "btn-default btn-red"
+        
+        %form.registration-form
+          .registration-form__content
+            %p.sms_non.message 30秒たっても認証番号が届かない方へ
+            %p.sms_non2.message 電話で認証番号を聞くこともできます。
+            %button.btn-default.btn-red{type: "~/signup/address"} 電話で認証番号を聞く（通話無料）
 
-      %h3
-        .tel__content
-          %p.sms_non.message 認証番号を再送することもできます。もう一度電話番号を入力してください。
-          %p.sms_non3.message - 
-          = link_to "電話番号を再度入力する" , "#", class:"qw"
-          %p.sms_non3.message - 
-          %p.sms_non2.message SMSが届かない場合は<a href="#">SMS受信設定</a>を確認して、もう一度電話番号を入力してください。
-          %image.image__kari{src: "https://i.gyazo.com/3115ad076f4ae0ac5d647ccec944218e.png"}
+        %h3
+          .tel__content
+            %p.sms_non.message 認証番号を再送することもできます。もう一度電話番号を入力してください。
+            %p.sms_non3.message - 
+            = link_to "電話番号を再度入力する" , "#", class:"qw"
+            %p.sms_non3.message - 
+            %p.sms_non2.message SMSが届かない場合は<a href="#">SMS受信設定</a>を確認して、もう一度電話番号を入力してください。
+            %image.image__kari{src: "https://i.gyazo.com/3115ad076f4ae0ac5d647ccec944218e.png"}


### PR DESCRIPTION
# What
修正箇所と関連ページは下記の通りです。

- CSSの適用範囲を修正
　signup/sms_authentication，sms_confirmation

- 初回でJSが読み込まれるように修正
　users/[id]

- 商品検索結果のアイテムに商品詳細へのリンクを適用
　items/search

- カレントユーザーの出品商品か否かで購入ボタンと編集ボタンのいずれかが表示されるように修正
　items/[id]

- item登録時のセレクタのhashを最適化
　items/new，edit

# Why
・作業時のCSS等の衝突を解消するため
・各ページを最新の作業状況にあわせるため

# Preview
## items/search → [id]
![9b06b000-fd31-4ebf-806d-dd35e07fca73_1](https://user-images.githubusercontent.com/52348865/70915350-0a97f680-205d-11ea-8633-e84ad82d550d.gif)

## users/[id]
![mypage](https://user-images.githubusercontent.com/52348865/70915018-7463d080-205c-11ea-9ebf-682c800f8dc1.gif)

